### PR TITLE
add flexibility to UT/LST constraints

### DIFF
--- a/js/visplot_helper.js
+++ b/js/visplot_helper.js
@@ -535,8 +535,12 @@ helper.ExtractUTRange = function (str) {
     if (str.length !== 2) {
         return false;
     }
-    let ut1 = helper.HMToEphemDate(str[0]);
-    let ut2 = helper.HMToEphemDate(str[1]);
+
+    // Convert decimal/d.dd to H:MM format
+    const str1 = helper.decimalToHHMM(str[0]);
+    const str2 = helper.decimalToHHMM(str[1]);
+    let ut1 = helper.HMToEphemDate(str1);
+    let ut2 = helper.HMToEphemDate(str2);
     if (ut1 === -1 || ut2 === -1) {
         return false;
     }
@@ -588,4 +592,14 @@ helper.validColour = function(stringToTest) {
     dummy.style.color = "rgb(255, 255, 255)";
     dummy.style.color = stringToTest;
     return dummy.style.color !== "rgb(255, 255, 255)";
+};
+
+/*
+ * convert string decimal d.dd to HH:MM
+*/
+helper.decimalToHHMM = function(text) {
+    if (text.includes(':') || !text.includes('.')) { return text; }
+    var parts = text.split('.');
+    parts[1] = helper.padTwoDigits(parseFloat(parts[1]) / 100 * 60.);
+    return parts[0] + ':' + parts[1];
 };

--- a/js/visplot_targets.js
+++ b/js/visplot_targets.js
@@ -1065,26 +1065,27 @@ TargetList.prototype.extractLineInfo = function (linenumber, linetext) {
         return false;
     }
     if (words[0] == 'BadWolf' || words[0] == 'Offline') {
-        if (words.length < 2 || words.length > 3) {
+        let words2 = linetext.split(/[\s]+/g);
+        if (words2.length < 2 || words2.length > 3) {
             helper.LogError('Error: Incorrect syntax on Line #' + linenumber + '; for offline time you must provide a valid UT range!');
             return false;
         }
-        if (words.length == 3) {
+        if (words2.length == 3) {
             if (words[1] != '*') {
                 helper.LogError('Error: Incorrect syntax on Line #' + linenumber + '; offline time must take "*" as [OBSTIME] argument!');
                 return false;
             }
         }
-        let q = (words.length == 2) ? 1 : 2;
-        let UTr = helper.ExtractUTRange(words[q]), ut1, ut2;
+        let q = (words2.length == 2) ? 1 : 2;
+        let UTr = helper.ExtractUTRange(words2[q]), ut1, ut2;
         if (UTr === false) {
-            helper.LogError('Error: Incorrect syntax in [CONSTRAINTS] on line #' + linenumber + ': the UT range must be a valid interval (e.g., [20:00-23:00] or [1-2])!');
+            helper.LogError('Error: Incorrect syntax in [CONSTRAINTS] on line #' + linenumber + ': the UT range must be a valid interval (e.g., [20:00-23:00], [1-2] or [4.5-6])!');
             return false;
         } else {
             this.BadWolfStart.push(UTr[0]);
             this.BadWolfEnd.push(UTr[1]);
         }
-        return [words[0], '', '', '', '', '', '', '', '*', '', words[q], ''];
+        return [words2[0], '', '', '', '', '', '', '', '*', '', words2[q], ''];
     }
     if (words.length == 6 && words[2].indexOf(':') == -1) {
         words = ['Object' + linenumber].concat(words);


### PR DESCRIPTION
Colons and dots on constraints for UT/LST (such as from the example below) do not seem to work consistently. This PR is an attempt to solve it. One part of the problem is splitting the input lines by whitespace and colon (breaks HH:MM format in constraints). The other part seems to be passing decimal numbers to HMToEphemDate to retrieve the UT.

Probably a more sophisticated solution exists, but this PR suggests only possible solution.

Sample input list:

```
Offline                           *        UT[21-22]                
Offline                           *        UT[22:30-22:45]         
Offline                           *        UT[23.45-00.30]         
Offline                           *        LST[10-11]              
Offline                           *        LST[12:30-13:00]        
Offline                           *        LST[14.5-15.0]          
test    10 00 00  20 00 00 2000 100 00-000 LST[7.0-15.0]    Monitor
```
